### PR TITLE
Feat: 급여관리, 일정관리 페이지에 Footer 추가

### DIFF
--- a/src/pages/home/home-page.jsx
+++ b/src/pages/home/home-page.jsx
@@ -22,6 +22,7 @@ function HomePage() {
 }
 
 const Container = styled.div`
+  /* padding: 50px 20px 0 0; */
   height: calc(100vh - 40px);
   display: flex;
   flex-direction: column;

--- a/src/pages/salary-management/salary-management-page.jsx
+++ b/src/pages/salary-management/salary-management-page.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import Footer from '@components/Footer/Footer'
 
 const PageContainer = styled.div`
+  /* padding: 50px 20px 0 0; */
   display: flex;
   flex-direction: column;
   height: calc(100vh - 40px);

--- a/src/pages/salary-management/salary-management-page.jsx
+++ b/src/pages/salary-management/salary-management-page.jsx
@@ -7,7 +7,7 @@ import Footer from '@components/Footer/Footer'
 const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: calc(100vh - 40px);
   max-width: 100vw;
 `
 
@@ -15,7 +15,7 @@ const ContentContainer = styled.div`
   display: flex;
   flex-direction: row;
   flex: 1;
-  margin-top: 20px;
+  margin: 20px 0;
   gap: 20px;
 `
 const StyledCalendar = styled(Calendar)`

--- a/src/pages/task-management/taskManagement-page.jsx
+++ b/src/pages/task-management/taskManagement-page.jsx
@@ -7,7 +7,7 @@ import Footer from '@components/Footer/Footer'
 const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: calc(100vh - 40px);
   max-width: 100vw;
 `
 
@@ -15,7 +15,7 @@ const ContentContainer = styled.div`
   display: flex;
   flex-direction: row;
   flex: 1;
-  margin-top: 20px;
+  margin: 20px 0;
   gap: 20px;
 `
 const StyledCalendar = styled(Calendar)`


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #40 Feat: 급여관리, 일정관리 페이지 Layout

## 📝작업 내용

> 급여관리와 일정관리 페이지에 있는 Footer를 홈페이지에 있는 Footer의 크기로 맞추고 여백 코드 주석처리 해놨습니다.
